### PR TITLE
deps: update ESLint from ^3.16.1 => ^4.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "semver": "^5.3.0"
   },
   "devDependencies": {
-    "eslint": "^3.16.1"
+    "eslint": "^4.18.2"
   },
   "repository": {
     "type": "git",

--- a/src/commands/depsdb.js
+++ b/src/commands/depsdb.js
@@ -135,7 +135,7 @@ async function resolved() {
           deps[dep].indexOf('://') !== -1 ||
           deps[dep].startsWith('github:') ||
           dep[0] === '@'
-        ) {
+      ) {
         continue;
       }
       const depVersion = matchVersion(dep, deps[dep]);

--- a/src/commands/extract.js
+++ b/src/commands/extract.js
@@ -45,7 +45,7 @@ async function loadExcluded() {
         x = `${x}(/|$)`;
       }
       x = x.replace(/\\\*/g, '.*')
-           .replace(/\\\?/g, '.');
+        .replace(/\\\?/g, '.');
       return new RegExp(x);
     });
   return excludedLoaded;
@@ -58,10 +58,10 @@ async function listTar(file) {
     { maxBuffer: 50 * 1024 * 1024 }
   );
   return tar.stdout
-            .split('\n')
-            .filter(x => !!x)
-            .filter(x => x !== 'package')
-            .sort();
+    .split('\n')
+    .filter(x => !!x)
+    .filter(x => x !== 'package')
+    .sort();
 }
 
 async function slimCode(ext, outdir, tgz, slim) {
@@ -185,7 +185,7 @@ async function partial(tgz, rebuild) {
       throw new Error('Package contains top-level files!');
     }
     files = lines.map(x => x.replace(/[^/]*\//, ''))
-                 .map(x => `${tgz}/${x}`);
+      .map(x => `${tgz}/${x}`);
     await writeList(path.join(outdir, 'files.txt'), files);
     // TODO: rebuild new extensions on extensions list changes
     for (const ext of extensions) {

--- a/src/commands/packages.js
+++ b/src/commands/packages.js
@@ -35,7 +35,7 @@ async function run() {
     }
 
     const url = info.tar.replace('http://', 'https://')
-                        .replace('registry.npmjs.org', 'registry.npmjs.com');
+      .replace('registry.npmjs.org', 'registry.npmjs.com');
     const file = url.replace(`https://registry.npmjs.com/${info.name}/-/`, '');
 
     if (file.replace(/[@0v-]/g, '') !== `${info.id.replace(/[@0v-]/g, '')}.tgz`) {

--- a/src/commands/server.js
+++ b/src/commands/server.js
@@ -12,7 +12,7 @@ async function run() {
 
   api.use(logger());
 
-  api.use(async (ctx, next) => {
+  api.use(async(ctx, next) => {
     ctx.res.on('close', () => {
       ctx.state.closed = true;
     });
@@ -45,7 +45,7 @@ async function run() {
       // TODO: handle early close
     });
 
-    setImmediate(async () => {
+    setImmediate(async() => {
       ctx.res.flushHeaders();
       await search.code(ctx.query.query, null, line =>
         ctx.body.write(`${line}\n`)

--- a/src/queue.js
+++ b/src/queue.js
@@ -1,7 +1,6 @@
 'use strict';
 
 class Queue {
-
   constructor(limit = 1) {
     this.limit = limit;
     this.busy = 0;


### PR DESCRIPTION
Updates ESLint (devDep) from `eslint@^3.16.1` to `eslint@^4.18.2`. This resolves a catastrophic backtracking security vulnerability that was determined by the ESLint team to be very unlikely to be exploited (ref: https://github.com/eslint/eslint/commit/f6901d0bcf6c918ac4e5c6c7c4bddeb2cb715c09)

Edits to additional files were generated by running `eslint --cache gzemnid.js src --fix`, since there were 11 errors from ESLint on running `npm run lint` after updating. After running the `--fix`, there are now no errors on my local machine. Here's a list of the errors that were resolved:

```text
/Users/cyren/GitHub/tmp/Gzemnid/src/commands/depsdb.js
  138:1  error  Expected indentation of 6 spaces but found 8  indent

/Users/cyren/GitHub/tmp/Gzemnid/src/commands/extract.js
   48:1  error  Expected indentation of 8 spaces but found 11  indent
   61:1  error  Expected indentation of 4 spaces but found 12  indent
   62:1  error  Expected indentation of 4 spaces but found 12  indent
   63:1  error  Expected indentation of 4 spaces but found 12  indent
   64:1  error  Expected indentation of 4 spaces but found 12  indent
  188:1  error  Expected indentation of 6 spaces but found 17  indent

/Users/cyren/GitHub/tmp/Gzemnid/src/commands/packages.js
  38:1  error  Expected indentation of 6 spaces but found 24  indent

/Users/cyren/GitHub/tmp/Gzemnid/src/commands/server.js
  15:16  error  Unexpected space before function parentheses  space-before-function-paren
  48:23  error  Unexpected space before function parentheses  space-before-function-paren

/Users/cyren/GitHub/tmp/Gzemnid/src/queue.js
  3:13  error  Block must not be padded by blank lines  padded-blocks
````